### PR TITLE
Support react-router-dom 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-admin-firebase",
   "description": "A firebase data provider for the React Admin framework",
-  "version": "5.1.0-beta.0",
+  "version": "5.1.0-beta.1",
   "peerDependencies": {
     "firebase": "9.x || 10.x || 11.x",
     "react": "17.x || 18.x || 19.x",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "react": "17.x || 18.x || 19.x",
     "react-admin": "4.x || 5.x",
     "react-dom": "17.x || 18.x || 19.x",
-    "react-router-dom": "5.x || 6.x"
+    "react-router-dom": "5.x || 6.x || 7.x"
   },
   "dependencies": {
     "lodash": "4.x",
@@ -20,7 +20,6 @@
     "@types/lodash": "^4.14.150",
     "@types/node": "^10.9.4",
     "@types/react": "^18.0.9",
-    "@types/react-router-dom": "^5.3.3",
     "@types/rx": "^4.1.1",
     "firebase": "^11.9.1",
     "firebase-tools": "11.x",
@@ -62,5 +61,6 @@
   "source": "src/index.ts",
   "engines": {
     "node": ">=10"
-  }
+  },
+  "packageManager": "yarn@4.9.2"
 }

--- a/src-demo/package.json
+++ b/src-demo/package.json
@@ -8,7 +8,7 @@
     "firebase": "^11.9.1",
     "react": "^19.x",
     "react-admin": "5",
-    "react-admin-firebase": "5.1.0-beta.0",
+    "react-admin-firebase": "5.1.0-beta.1",
     "react-dom": "^19.x",
     "react-firebaseui": "^6.0.0",
     "react-router-dom": "^7.x",

--- a/src-demo/package.json
+++ b/src-demo/package.json
@@ -11,7 +11,7 @@
     "react-admin-firebase": "5.1.0-beta.0",
     "react-dom": "^19.x",
     "react-firebaseui": "^6.0.0",
-    "react-router-dom": "^6.x",
+    "react-router-dom": "^7.x",
     "react-scripts": "^5.0.0",
     "source-map-loader": "^3"
   },


### PR DESCRIPTION
## Summary
- allow react-router-dom 7 in peer dependencies
- bump demo app's react-router-dom to ^7.x
- remove unused @types/react-router-dom dev dependency

## Testing
- `yarn install --frozen-lockfile`
- `yarn test` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_685f101ba06883249aa83e4187ca1b73